### PR TITLE
fix: use correct DTO namespace, add `laravel-typescript-transformer`

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -172,8 +172,8 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 				match: /'collectors' => \[/,
 				position: 'after',
 				lines: [
-					'Hybridly\Support\TypeScriptTransformer\DataResourceTypeScriptCollector::class,',
-					'Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptCollector::class,'
+					'Hybridly\\Support\\TypeScriptTransformer\\DataResourceTypeScriptCollector::class,',
+					'Spatie\\LaravelData\\Support\\TypeScriptTransformer\\DataTypeScriptCollector::class,'
 				]
 			},
 			{
@@ -186,8 +186,8 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 				match: /'transformers' => \[/,
 				position: 'after',
 				lines: [
-					'Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer::class,',
-					'Spatie\TypeScriptTransformer\Transformers\EnumTransformer::class,'
+					'Spatie\\LaravelData\\Support\\TypeScriptTransformer\\DataTypeScriptTransformer::class,',
+					'Spatie\\TypeScriptTransformer\\Transformers\\EnumTransformer::class,'
 				]
 			}
 		],

--- a/preset.ts
+++ b/preset.ts
@@ -160,32 +160,34 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 	})
 	
 	await editFiles({
-		title: "update typescript transformer config",
-		files: "config/typescript-transformer.php",
+		title: 'update typescript transformer config',
+		files: 'config/typescript-transformer.php',
 		operations: [
 			{
-				type: "remove-line",
+				type: 'remove-line',
 				match: /Spatie\\TypeScriptTransformer\\Collectors\\DefaultCollector::class,/
 			},
 			{
-				type: "add-line",
-				match: /"collectors" => \[/,
+				type: 'add-line',
+				match: /'collectors' => \[/,
+				position: 'after',
 				lines: [
-					"Hybridly\Support\TypeScriptTransformer\DataResourceTypeScriptCollector::class,",
-					"Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptCollector::class,"
+					'Hybridly\Support\TypeScriptTransformer\DataResourceTypeScriptCollector::class,',
+					'Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptCollector::class,'
 				]
 			},
 			{
-				type: "remove-line",
+				type: 'remove-line',
 				match: /Spatie\\LaravelTypeScriptTransformer\\Transformers\\SpatieStateTransformer::class,/,
 				count: 3
 			},
 			{
-				type: "add-line",
-				match: /"collectors" => \[/,
+				type: 'add-line',
+				match: /'transformers' => \[/,
+				position: 'after',
 				lines: [
-					"Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer::class,",
-					"Spatie\TypeScriptTransformer\Transformers\EnumTransformer::class,"
+					'Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer::class,',
+					'Spatie\TypeScriptTransformer\Transformers\EnumTransformer::class,'
 				]
 			}
 		],

--- a/preset.ts
+++ b/preset.ts
@@ -143,6 +143,7 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 		packages: [
 			'hybridly/laravel',
 			'spatie/laravel-data',
+			'spatie/laravel-typescript-transformer'
 		],
 	})
 

--- a/preset.ts
+++ b/preset.ts
@@ -152,6 +152,44 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 		command: 'php',
 		arguments: ['artisan', 'hybridly:install'],
 	})
+	
+	await executeCommand({
+		title: 'publish typescript transformer config',
+		command: 'php',
+		arguments: ['artisan', 'vendor:publish', '--tag=typescript-transformer-config'],
+	})
+	
+	await editFiles({
+		title: "update typescript transformer config",
+		files: "config/typescript-transformer.php",
+		operations: [
+			{
+				type: "remove-line",
+				match: /Spatie\\TypeScriptTransformer\\Collectors\\DefaultCollector::class,/
+			},
+			{
+				type: "add-line",
+				match: /"collectors" => \[/,
+				lines: [
+					"Hybridly\Support\TypeScriptTransformer\DataResourceTypeScriptCollector::class,",
+					"Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptCollector::class,"
+				]
+			},
+			{
+				type: "remove-line",
+				match: /Spatie\\LaravelTypeScriptTransformer\\Transformers\\SpatieStateTransformer::class,/,
+				count: 3
+			},
+			{
+				type: "add-line",
+				match: /"collectors" => \[/,
+				lines: [
+					"Spatie\LaravelData\Support\TypeScriptTransformer\DataTypeScriptTransformer::class,",
+					"Spatie\TypeScriptTransformer\Transformers\EnumTransformer::class,"
+				]
+			}
+		],
+	});
 
 	await editFiles({
 		title: 'update welcome route',

--- a/templates/base/app/Data/SecurityData.php
+++ b/templates/base/app/Data/SecurityData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Data\Hybridly;
+namespace App\Data;
 
 use App\Data\UserData;
 use Spatie\LaravelData\Data;
@@ -8,8 +8,7 @@ use Spatie\LaravelData\Data;
 class SecurityData extends Data
 {
     public function __construct(
-        public readonly ?UserData $user,
-        public readonly int $characters,
+        public readonly ?UserData $user
     ) {
     }
 }

--- a/templates/base/app/Data/SharedData.php
+++ b/templates/base/app/Data/SharedData.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Data\Hybridly;
+namespace App\Data;
 
 use Spatie\LaravelData\Data;
 

--- a/templates/base/resources/types/hybridly.d.ts
+++ b/templates/base/resources/types/hybridly.d.ts
@@ -1,4 +1,4 @@
-interface GlobalHybridlyProperties extends App.Data.Hybridly.SharedData {
+interface GlobalHybridlyProperties extends App.Data.SharedData {
 	flash: {
 		success?: string
 		error?: string


### PR DESCRIPTION
Hey, 

- removed Hybridly from the namespace of the DTO files 
- added spatie/laravel-typescript-transformer as a composer dependency 
- publish the typescript transformer config file
- update the config with hybridly's transformer & collector

SK