### PR TITLE
fix: upgrade `i18n` integration to support Vite 4

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -115,7 +115,7 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 			...(icons ? ['unplugin-icons'] : []),
 			// i18n
 			...(i18n ? [
-				'@intlify/vite-plugin-vue-i18n',
+				'@intlify/unplugin-vue-i18n',
 				'vue-i18n',
 			] : []),
 		],
@@ -340,7 +340,7 @@ async function installI18n() {
 				type: 'add-line',
 				match: /import run from 'vite-plugin-run'/,
 				position: 'after',
-				lines: "import i18n from '@intlify/vite-plugin-vue-i18n'",
+				lines: "import i18n from '@intlify/unplugin-vue-i18n'",
 			},
 			// add plugin
 			{

--- a/preset.ts
+++ b/preset.ts
@@ -340,7 +340,7 @@ async function installI18n() {
 				type: 'add-line',
 				match: /import run from 'vite-plugin-run'/,
 				position: 'after',
-				lines: "import i18n from '@intlify/unplugin-vue-i18n'",
+				lines: "import i18n from '@intlify/unplugin-vue-i18n/vite'",
 			},
 			// add plugin
 			{


### PR DESCRIPTION
This PR fixes a Vite 4 compatibility problem when using the `--i18n` flag, such as the following command.

```bash
npx @preset/cli apply hybridly/preset --i18n
```

<details>

  <summary>Error log</summary>

```
  ×  Failed action: add npm dependencies (node)
     ↪  Command failed with exit code 1: npm install -D hybridly axios @types/node typescript vue @vitejs/plugin-vue @vue/ru
ntime-core @vueuse/core @vueuse/head laravel-vite-plugin vite-plugin-run autoprefixer tailwindcss postcss @tailwindcss/forms
 unplugin-auto-import unplugin-vue-components unplugin-icons @intlify/vite-plugin-vue-i18n vue-i18n
      npm ERR! code ERESOLVE
      npm ERR! ERESOLVE could not resolve
      npm ERR!
      npm ERR! While resolving: @intlify/vite-plugin-vue-i18n@7.0.0
      npm ERR! Found: vite@4.0.3
      npm ERR! node_modules/vite
      npm ERR!   dev vite@"^4.0.0" from the root project
      npm ERR!   peer vite@"^4.0.0" from @vitejs/plugin-vue@4.0.0
      npm ERR!   node_modules/@vitejs/plugin-vue
      npm ERR!     dev @vitejs/plugin-vue@"*" from the root project
      npm ERR!   1 more (laravel-vite-plugin)
      npm ERR!
      npm ERR! Could not resolve dependency:
      npm ERR! peerOptional vite@"^2.9.0 || ^3.0.0" from @intlify/vite-plugin-vue-i18n@7.0.0
      npm ERR! node_modules/@intlify/vite-plugin-vue-i18n
      npm ERR!   dev @intlify/vite-plugin-vue-i18n@"*" from the root project
      npm ERR!
      npm ERR! Conflicting peer dependency: vite@3.2.5
      npm ERR! node_modules/vite
      npm ERR!   peerOptional vite@"^2.9.0 || ^3.0.0" from @intlify/vite-plugin-vue-i18n@7.0.0
      npm ERR!   node_modules/@intlify/vite-plugin-vue-i18n
      npm ERR!     dev @intlify/vite-plugin-vue-i18n@"*" from the root project
      npm ERR!
      npm ERR! Fix the upstream dependency conflict, or retry
      npm ERR! this command with --force or --legacy-peer-deps
      npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
      npm ERR!
      npm ERR!
      npm ERR! For a full report see:
      npm ERR! /Users/nicolas/.npm/_logs/2022-12-27T21_20_32_411Z-eresolve-report.txt

      npm ERR! A complete log of this run can be found in:
      npm ERR!     /Users/nicolas/.npm/_logs/2022-12-27T21_20_32_411Z-debug-0.log
```

</details>

The preset currently uses `@intlify/vite-plugin-vue-i18n` which is only compatible up to Vite 3. [As mentioned on the package's NPM page](https://www.npmjs.com/package/@intlify/vite-plugin-vue-i18n), for Vite 4, the `@intlify/unplugin-vue-i18n` package should be used instead.

I've applied my modified preset to a test project and was able to successfully compile the frontend application without any errors.