### PR TITLE
fix(templates): add line height to welcome page title

### DIFF
--- a/templates/base/resources/views/pages/welcome.vue
+++ b/templates/base/resources/views/pages/welcome.vue
@@ -36,7 +36,7 @@ import Block from '@/views/components/block.vue'
 							</linearGradient>
 						</defs>
 					</svg>
-					<span class="title font-bold bg-clip-text text-center text-6xl text-transparent">Hybridly</span>
+					<span class="title font-bold bg-clip-text text-center text-6xl text-transparent leading-normal">Hybridly</span>
 				</div>
 			</div>
 


### PR DESCRIPTION
I noticed the Hybridly text is cut vertically:
![image](https://user-images.githubusercontent.com/15275787/211547550-7d30d403-3416-4651-ac5b-3d63e094771c.png)
With line height added:
![image](https://user-images.githubusercontent.com/15275787/211547698-24f91c4b-5962-4fd2-ab9c-670b46ff80ed.png)
