### PR TITLE
feat: improve strict mode

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -418,9 +418,11 @@ async function applyStrictMode() {
 				lines: [
 					'use Carbon\\CarbonImmutable;',
 					'use Illuminate\\Database\\Eloquent\\Model;',
+					'use Illuminate\Database\Eloquent\Relations\Relation;',
 					'use Illuminate\\Foundation\\Console\\CliDumper;',
 					'use Illuminate\\Foundation\\Http\\HtmlDumper;',
 					'use Illuminate\\Support\\Facades\\Date;',
+					'use Illuminate\\Support\\Facades\\Validator;',
 				],
 			},
 			{
@@ -432,8 +434,10 @@ async function applyStrictMode() {
 					'    HtmlDumper::dontIncludeSource();',
 					'    CliDumper::dontIncludeSource();',
 					'',
+					'    Validator::excludeUnvalidatedArrayKeys();',
 					'    Model::shouldBeStrict();',
 					'    Model::unguard();',
+					'    Relation::enforceMorphMap([]);',
 					'    Date::use(CarbonImmutable::class);',
 				],
 			},

--- a/preset.ts
+++ b/preset.ts
@@ -427,7 +427,7 @@ async function applyStrictMode() {
 			},
 			{
 				type: 'add-line',
-				match: /public function register\(\)/,
+				match: /public function boot\(\)/,
 				position: 'after',
 				lines: [
 					'{',

--- a/preset.ts
+++ b/preset.ts
@@ -416,6 +416,7 @@ async function applyStrictMode() {
 				match: /use Illuminate\\Support\\ServiceProvider;/,
 				position: 'after',
 				lines: [
+					'use App\\Models\\User;',
 					'use Carbon\\CarbonImmutable;',
 					'use Illuminate\\Database\\Eloquent\\Model;',
 					'use Illuminate\\Database\\Eloquent\\Relations\\Relation;',
@@ -437,7 +438,9 @@ async function applyStrictMode() {
 					'    Validator::excludeUnvalidatedArrayKeys();',
 					'    Model::shouldBeStrict();',
 					'    Model::unguard();',
-					'    Relation::enforceMorphMap([]);',
+					'    Relation::enforceMorphMap([',
+					"        'user' => User::class,",
+					'    ]);',
 					'    Date::use(CarbonImmutable::class);',
 				],
 			},

--- a/preset.ts
+++ b/preset.ts
@@ -418,7 +418,7 @@ async function applyStrictMode() {
 				lines: [
 					'use Carbon\\CarbonImmutable;',
 					'use Illuminate\\Database\\Eloquent\\Model;',
-					'use Illuminate\Database\Eloquent\Relations\Relation;',
+					'use Illuminate\\Database\\Eloquent\\Relations\\Relation;',
 					'use Illuminate\\Foundation\\Console\\CliDumper;',
 					'use Illuminate\\Foundation\\Http\\HtmlDumper;',
 					'use Illuminate\\Support\\Facades\\Date;',


### PR DESCRIPTION
I had to change the method from `register` to `boot` otherwise `Validator::excludeUnvalidatedArrayKeys` did not work.
For so far I can see this has no disadvantages, but please do a double check.

# Validator::excludeUnvalidatedArrayKeys
Indicates that unvalidated array keys should be excluded, even if the parent array was validated.

# Relation::enforceMorphMap
Define the morph map for polymorphic relations and require all morphed models to be explicitly mapped.
