### PR TITLE
fix: install `laravel-typescript-transformer` as a dev dependency

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -181,7 +181,7 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 	})
 	
 	await installPackages({
-		title: 'add php dependencies',
+		title: 'add php dev dependencies',
 		for: 'php',
 		dev: true,
 		packages: [

--- a/preset.ts
+++ b/preset.ts
@@ -177,6 +177,14 @@ async function installBase({ autoImports, i18n, icons }: Options) {
 		packages: [
 			'hybridly/laravel',
 			'spatie/laravel-data',
+		],
+	})
+	
+	await installPackages({
+		title: 'add php dependencies',
+		for: 'php',
+		dev: true,
+		packages: [
 			'spatie/laravel-typescript-transformer',
 		],
 	})


### PR DESCRIPTION
I think `spatie/laravel-typescript-transformer` can be added as `dev` package.