### PR TITLE
fix: move withoutVite to TestCase class

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -280,33 +280,7 @@ async function installI18n() {
 	})
 }
 
-async function applyStrictMode() {
-    await editFiles({
-		title: 'update TestCase.php',
-		files: 'tests/TestCase.php',
-		operations: [
-            {
-                type: 'add-line',
-                position: 'after',
-                match: /use Illuminate\Foundation\Testing\TestCase as BaseTestCase/,
-                skipIf: (content) => content.includes('use Illuminate\Support\Facades\Http'),
-                lines: [
-                    'use Illuminate\Support\Facades\Http;',
-                ],
-            },
-            {
-                type: 'add-line',
-                position: 'after',
-                match: /$this->withoutVite()/,
-                skipIf: (content) => content.includes('Http::preventStrayRequests()'),
-                lines: [
-                    '',
-                    'Http::preventStrayRequests();',
-                ],
-            },
-        ],
-	})
-    
+async function applyStrictMode() {    
 	await editFiles({
 		files: 'app/Providers/AppServiceProvider.php',
 		operations: [

--- a/preset.ts
+++ b/preset.ts
@@ -59,19 +59,20 @@ async function installBase({ i18n }: Options) {
 	})
 
 	await editFiles({
-		title: 'update CreatesApplication.php',
-		files: 'tests/CreatesApplication.php',
-		operations: {
-			type: 'add-line',
-			position: 'after',
-			match: /\$app->make\(Kernel::class\)/,
-			lines: [
-				'',
-				'$this->afterApplicationCreated(function () {',
-				'    $this->withoutVite();',
-				'});',
-			],
-		},
+		title: 'update TestCase.php',
+		files: 'tests/TestCase.php',
+		operations: [
+            {
+                type: 'add-line',
+                position: 'after',
+                match: /parent::setUp()/,
+                skipIf: (content) => content.includes('$this->withoutVite()'),
+                lines: [
+                    '',
+                    '$this->withoutVite();',
+                ],
+            },
+        ],
 	})
 
 	await editFiles({
@@ -296,6 +297,32 @@ async function installI18n() {
 }
 
 async function applyStrictMode() {
+    await editFiles({
+		title: 'update TestCase.php',
+		files: 'tests/TestCase.php',
+		operations: [
+            {
+                type: 'add-line',
+                position: 'after',
+                match: /use Illuminate\Foundation\Testing\TestCase as BaseTestCase/,
+                skipIf: (content) => content.includes('use Illuminate\Support\Facades\Http'),
+                lines: [
+                    'use Illuminate\Support\Facades\Http;',
+                ],
+            },
+            {
+                type: 'add-line',
+                position: 'after',
+                match: /$this->withoutVite()/,
+                skipIf: (content) => content.includes('Http::preventStrayRequests()'),
+                lines: [
+                    '',
+                    'Http::preventStrayRequests();',
+                ],
+            },
+        ],
+	})
+    
 	await editFiles({
 		files: 'app/Providers/AppServiceProvider.php',
 		operations: [

--- a/preset.ts
+++ b/preset.ts
@@ -58,22 +58,6 @@ async function installBase({ i18n }: Options) {
 		},
 	})
 
-	await editFiles({
-		title: 'update TestCase.php',
-		files: 'tests/TestCase.php',
-		operations: [
-            {
-                type: 'add-line',
-                position: 'after',
-                match: /parent::setUp()/,
-                skipIf: (content) => content.includes('$this->withoutVite()'),
-                lines: [
-                    '',
-                    '$this->withoutVite();',
-                ],
-            },
-        ],
-	})
 
 	await editFiles({
 		title: 'update Kernel.php',

--- a/preset.ts
+++ b/preset.ts
@@ -280,7 +280,7 @@ async function installI18n() {
 	})
 }
 
-async function applyStrictMode() {    
+async function applyStrictMode() {
 	await editFiles({
 		files: 'app/Providers/AppServiceProvider.php',
 		operations: [

--- a/templates/base/tests/TestCase.php
+++ b/templates/base/tests/TestCase.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+
+abstract class TestCase extends BaseTestCase
+{
+    use CreatesApplication;
+    use LazilyRefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+}

--- a/templates/base/tests/TestCase.php
+++ b/templates/base/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\Http;
 
 abstract class TestCase extends BaseTestCase
 {
@@ -17,5 +18,7 @@ abstract class TestCase extends BaseTestCase
         parent::setUp();
 
         $this->withoutVite();
+        
+        Http::preventStrayRequests();
     }
 }


### PR DESCRIPTION
Move `withoutVite` to the TestCase class as suggested by Laravel:
https://laravel.com/docs/10.x/vite#disabling-vite-in-tests

Otherwise it gives errors with running Pest in parallel. 

Do you want `Http::preventStrayRequests();` to be optional, removed, or only with strict?