### PR TITLE
fix: always pull latest version of `hybridly/laravel`

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -152,7 +152,7 @@ async function installBase({ i18n, ide }: Options) {
 		title: 'add php dependencies',
 		for: 'php',
 		packages: [
-			'hybridly/laravel:0.1.0',
+			'hybridly/laravel',
 			'spatie/laravel-data',
 		],
 	})


### PR DESCRIPTION
This PR:

- [x] Removes the version constraint on the `hybridly/laravel` package to always pull the latest version.

I think it's fair to say that we always want the latest version of Hybridly when setting it up in a new project.