### PR TITLE
chore: remove no longer necessary fix

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -210,16 +210,6 @@ async function installBase({ i18n, ide }: Options) {
 		],
 	})
 
-	// Fixes view:cache
-	await editFiles({
-		title: 'update views config',
-		files: 'config/view.php',
-		operations: {
-			type: 'update-content',
-			update: (content) => content.replace('resource_path(\'views\')', 'resource_path()'),
-		},
-	})
-
 	await editFiles({
 		title: 'update welcome route',
 		files: 'routes/web.php',


### PR DESCRIPTION
I believe this is no longer necessary with the latest version of Hybridly.

See https://github.com/hybridly/hybridly/issues/88, https://github.com/hybridly/hybridly/issues/88#issuecomment-1662734600