### PR TITLE
fix: unhead setup

### DIFF
--- a/templates/base/resources/application/main.ts
+++ b/templates/base/resources/application/main.ts
@@ -1,11 +1,13 @@
 import { initializeHybridly } from 'virtual:hybridly/config'
-import { createHead } from '@unhead/vue'
+import { createHead, useHead } from '@unhead/vue'
 import './tailwind.css'
 
 initializeHybridly({
 	enhanceVue: (vue) => {
-		vue.use(createHead({
+		vue.use(createHead()))
+		
+		useHead({
 			titleTemplate: (title) => title ? `${title} — Hybridly` : 'Hybridly',
-		}))
+		}
 	},
 })


### PR DESCRIPTION
This PR fixes the unhead setup.

The `createHead` function does not accept a `titleTemplate` property.