### PR TITLE
fix: use `CarbonInterface` instead of `Carbon`

### DIFF
--- a/templates/base/app/Data/UserData.php
+++ b/templates/base/app/Data/UserData.php
@@ -2,7 +2,7 @@
 
 namespace App\Data;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Spatie\LaravelData\Data;
 
 final class UserData extends Data
@@ -11,7 +11,7 @@ final class UserData extends Data
         public readonly ?int $id,
         public readonly string $name,
         public readonly string $email,
-        public readonly ?Carbon $email_verified_at,
+        public readonly ?CarbonInterface $email_verified_at,
     ) {
     }
 }


### PR DESCRIPTION
This PR fixes an issue where Laravel Data cannot serialize a data object if it contains a Carbon type. This PR replaces it with CarbonInterface, which works as expected.

<img width="713" alt="Screenshot 2023-11-25 at 20 14 51" src="https://github.com/hybridly/preset/assets/649677/d4fcbc54-08f1-41a1-b8e8-3530fd002b22">
