### PR TITLE
fix: unhead warning

### DIFF
--- a/templates/base/resources/application/main.ts
+++ b/templates/base/resources/application/main.ts
@@ -4,10 +4,10 @@ import './tailwind.css'
 
 initializeHybridly({
 	enhanceVue: (vue) => {
-		vue.use(createHead())
-		
-		useHead({
+		const head = createHead();
+		head.push({
 			titleTemplate: (title) => title ? `${title} — Hybridly` : 'Hybridly',
-		})
+		});
+		vue.use(head);
 	},
 })


### PR DESCRIPTION
Admittedly less elegant but it removes the unhead warning

![Screenshot 2024-01-07 at 19 38 19](https://github.com/hybridly/preset/assets/649677/fb47fb69-2219-47f8-821d-a4e6ecc38641)
